### PR TITLE
Whitelist addresses in staking contract

### DIFF
--- a/contracts/MainframeStake.sol
+++ b/contracts/MainframeStake.sol
@@ -27,7 +27,7 @@ contract MainframeStake is Ownable {
 
   function MainframeStake(address _tokenAddress) public {
     token = MainframeToken(_tokenAddress);
-    requiredStake = 1;
+    requiredStake = 1 ether; // ether = 10^18
     owner = msg.sender;
   }
 

--- a/contracts/MainframeToken.sol
+++ b/contracts/MainframeToken.sol
@@ -5,7 +5,7 @@ import "zeppelin-solidity/contracts/token/ERC20/PausableToken.sol";
 contract MainframeToken is PausableToken {
     string  public  constant name = "Mainframe Token";
     string  public  constant symbol = "MFT";
-    uint8   public  constant decimals = 8;
+    uint8   public  constant decimals = 18;
 
     modifier validDestination( address to )
     {
@@ -17,7 +17,7 @@ contract MainframeToken is PausableToken {
     function MainframeToken() public
     {
         // assign the total tokens to mainframe
-        totalSupply_ = 1000000000000000000; // 10 billion, 8 decimals
+        totalSupply_ = 10000000000 * 10**18; // 10 billion, 18 decimals
         balances[msg.sender] = totalSupply_;
         Transfer(address(0x0), msg.sender, totalSupply_);
     }

--- a/test/TestMainframeStake.js
+++ b/test/TestMainframeStake.js
@@ -4,6 +4,12 @@ const utils = require('./utils.js')
 
 contract('MainframeStake', (accounts) => {
 
+  it('should set correct required stake', async () => {
+    const stakeContract = await MainframeStake.deployed()
+    const requiredStake = await stakeContract.requiredStake()
+    assert.equal(requiredStake, 1e18)
+  })
+
   it('should whitelist address when staking', async () => {
     const tokenContract = await MainframeToken.deployed()
     const stakeContract = await MainframeStake.deployed()

--- a/test/TestMainframeToken.js
+++ b/test/TestMainframeToken.js
@@ -15,10 +15,10 @@ contract('MainframeToken', (accounts) => {
     assert.equal(symbol, 'MFT')
   })
 
-  it('should have 8 decimals', async () => {
+  it('should have 18 decimals', async () => {
     const token = await MainframeToken.deployed()
     const decimals = await token.decimals.call()
-    assert.equal(decimals, 8)
+    assert.equal(decimals, 18)
   })
 
   it('should assign creator as owner', async () => {
@@ -30,7 +30,7 @@ contract('MainframeToken', (accounts) => {
   it('should assign initial token supply to owner', async () => {
     const token = await MainframeToken.deployed()
     const ownersBalance = await token.balanceOf.call(accounts[0])
-    assert.equal(1e18, ownersBalance)
+    assert.equal(1e28, ownersBalance)
   })
 
   it('should allow transfer of ownership by owner', async () => {


### PR DESCRIPTION
This keeps a record of white listed addresses with a mapping of address to owner like:

whitelistedAddress => {
  address owner;
  uint stake;
}

This makes it straight forward and efficient for checking address has stake. However I realised there's probably a need for a user to withdraw their whole balance and remove all whitelisted addresses in one transaction, which wouldn't be possible with just the mapping as you are not able to iterate over it. So I've added a record of each stakers whitelisted addresses as an array alongside their balance info.

stakersAddress => {
  uint balance;
  address[] whitelistedAddresses;
}

This enables iteration over all their addresses in a withdrawFullBalance function but has the downside of maintaining two different data stores. Let me know your thoughts or if you have any ideas on how to achieve the same thing in a better way.