### PR TITLE
Allow distributor to transfer tokens when paused, make token claimable

### DIFF
--- a/contracts/MainframeToken.sol
+++ b/contracts/MainframeToken.sol
@@ -47,16 +47,16 @@ contract MainframeToken is ERC827Token, Pausable, Claimable {
 
   // ERC827 Methods
 
-  function transfer(address to, uint256 value, bytes data) public validDestination(to) isTradeable returns (bool) {
-    return super.transfer(to, value, data);
+  function transferAndCall(address to, uint256 value, bytes data) public validDestination(to) payable isTradeable returns (bool) {
+    return super.transferAndCall(to, value, data);
   }
 
-  function transferFrom(address from, address to, uint256 value, bytes data) public validDestination(to) isTradeable returns (bool) {
-    return super.transferFrom(from, to, value, data);
+  function transferFromAndCall(address from, address to, uint256 value, bytes data) public validDestination(to) payable isTradeable returns (bool) {
+    return super.transferFromAndCall(from, to, value, data);
   }
 
-  function approve(address spender, uint256 value, bytes data) public isTradeable returns (bool) {
-    return super.approve(spender, value, data);
+  function approveAndCall(address spender, uint256 value, bytes data) public payable isTradeable returns (bool) {
+    return super.approveAndCall(spender, value, data);
   }
 
   // Setters

--- a/contracts/MainframeToken.sol
+++ b/contracts/MainframeToken.sol
@@ -2,8 +2,9 @@ pragma solidity ^0.4.21;
 
 import "zeppelin-solidity/contracts/token/ERC827/ERC827Token.sol";
 import "zeppelin-solidity/contracts/lifecycle/Pausable.sol";
+import "zeppelin-solidity/contracts/ownership/Claimable.sol";
 
-contract MainframeToken is ERC827Token, Pausable {
+contract MainframeToken is ERC827Token, Pausable, Claimable {
   string public constant name = "Mainframe Token";
   string public constant symbol = "MFT";
   uint8  public constant decimals = 18;

--- a/contracts/MainframeTokenDistribution.sol
+++ b/contracts/MainframeTokenDistribution.sol
@@ -29,7 +29,7 @@ contract MainframeTokenDistribution is Ownable {
     for(uint i = 0; i < recipients.length; i++) {
       if(values[i] > 0) {
         require(mainframeToken.transferFrom(tokenOwner, recipients[i], values[i]));
-        TokensDistributed(recipients[i], values[i]);
+        emit TokensDistributed(recipients[i], values[i]);
         totalDistributed += values[i];
       }
     }

--- a/test/TestMainframeStake.js
+++ b/test/TestMainframeStake.js
@@ -10,7 +10,6 @@ contract('MainframeStake', (accounts) => {
   beforeEach('setup contracts for each test', async() => {
     tokenContract = await MainframeToken.new()
     stakeContract = await MainframeStake.new(tokenContract.address)
-    await tokenContract.turnOnTradeable({ from: accounts[0] })
   })
 
   it('should assign creator as owner', async () => {
@@ -226,7 +225,6 @@ contract('MainframeStake', (accounts) => {
   })
 
   it('should fail to destroy itself if someone sends tokens to the contract address', async () => {
-    await tokenContract.turnOnTradeable({from: accounts[0]})
     await tokenContract.transfer(stakeContract.address, 200, {from: accounts[0]})
     const didFail = await utils.expectAsyncThrow(async () => {
       await stakeContract.destroy()
@@ -238,7 +236,6 @@ contract('MainframeStake', (accounts) => {
     let totalBalance
     let totalDepositBalance
     const requiredStake = await stakeContract.requiredStake()
-    await tokenContract.turnOnTradeable({from: accounts[0]})
     await tokenContract.approve(stakeContract.address, requiredStake, {from: accounts[0], value: 0})
     await stakeContract.stake(accounts[0], accounts[0], {from: accounts[0], value: 0})
     await utils.assertEvent(stakeContract, {event: 'Deposit'})

--- a/test/TestMainframeStake.js
+++ b/test/TestMainframeStake.js
@@ -1,7 +1,6 @@
 const MainframeToken = artifacts.require('MainframeToken.sol')
 const MainframeStake = artifacts.require('MainframeStake.sol')
 const utils = require('./utils.js')
-const ethjsABI = require('ethjs-abi')
 
 contract('MainframeStake', (accounts) => {
   let tokenContract
@@ -125,13 +124,8 @@ contract('MainframeStake', (accounts) => {
   it('should approve and stake in a single transaction', async () => {
     const requiredStake = await stakeContract.requiredStake()
     const extraData = stakeContract.contract.stake.getData(accounts[0], accounts[0])
-
-    const abiMethod = utils.findMethod(tokenContract.abi, 'approve', 'address,uint256,bytes')
-    const args = [stakeContract.address, requiredStake, extraData]
-    const transferData = ethjsABI.encodeMethod(abiMethod, args)
-    await tokenContract.sendTransaction({from: accounts[0], data: transferData})
+    await tokenContract.approveAndCall(stakeContract.address, requiredStake, extraData, { from: accounts[0]})
     await utils.assertEvent(tokenContract, { event: 'Approval' })
-
     const depositorsBalance = await stakeContract.balanceOf(accounts[0])
     const totalDepositBalance = await stakeContract.totalDepositBalance()
     const totalBalance = await tokenContract.balanceOf(stakeContract.address)

--- a/test/TestMainframeToken.js
+++ b/test/TestMainframeToken.js
@@ -45,11 +45,20 @@ contract('MainframeToken', (accounts) => {
     assert.equal(expected.toString(), ownersBalance.toString(), 'incorrect assignment of initial token supply')
   })
 
-  it('should allow transfer of ownership by owner', async () => {
+  it('should allow transfer of ownership by owner to pending owner', async () => {
     await token.transferOwnership(accounts[1], { from: accounts[0] })
+    await token.claimOwnership({ from: accounts[1] })
     const owner = await token.owner.call()
     assert.equal(accounts[1], owner, 'failed transfer of ownership')
     await token.transferOwnership(accounts[0], { from: accounts[1] })
+  })
+
+  it('should not allow ownership to be claimed by non pending owner', async () => {
+    await token.transferOwnership(accounts[1], { from: accounts[0] })
+    const didFail = await utils.expectAsyncThrow(async () => {
+      await token.claimOwnership({ from: accounts[2] })
+    })
+    assert(didFail, 'ownership claimed by non pending owner')
   })
 
   it('should not allow transfer of ownership by non owner', async () => {

--- a/test/TestMainframeToken.js
+++ b/test/TestMainframeToken.js
@@ -59,21 +59,39 @@ contract('MainframeToken', (accounts) => {
     assert(didFail, 'tranferred ownership by non owner')
   })
 
-  it('should not allow transfer by non owner if tradeable is false ', async () => {
+  it('should not allow transfer by non owner when paused', async () => {
+    await token.pause({ from: accounts[0] })
     await token.transfer(accounts[1], txAmount, { from: accounts[0] })
     const failed = await utils.expectAsyncThrow(async () => {
       await token.transfer(accounts[2], txAmount, { from: accounts[1] })
     })
-    assert(failed, 'allowed transfer by non owner when not tradeable')
+    assert(failed, 'allowed transfer by non owner when paused')
   })
 
-  it('should allow transfer of tokens by owner when tradeable is false', async () => {
+  it('should allow transfer of tokens by owner when paused', async () => {
+    await token.pause({ from: accounts[0] })
     const starting0Balance = await token.balanceOf(accounts[0])
     const starting1Balance = await token.balanceOf(accounts[1])
     await token.transfer(accounts[1], txAmount, { from: accounts[0] })
     await utils.assertEvent(token, { event: 'Transfer' })
     const ending0Balance = await token.balanceOf(accounts[0])
     const ending1Balance = await token.balanceOf(accounts[1])
+    const expected0Bal = starting0Balance.minus(txAmount)
+    const expected1Bal = starting1Balance.plus(txAmount)
+    assert.equal(ending0Balance.toString(), expected0Bal.toString(), 'Balance of account 0 incorrect')
+    assert.equal(ending1Balance.toString(), expected1Bal.toString(), 'Balance of account 1 incorrect')
+  })
+
+  it('should allow transfer of tokens by distributor when paused', async () => {
+    await token.transfer(accounts[1], txAmount, { from: accounts[0] })
+    await token.setDistributor(accounts[1], { from: accounts[0] })
+    await token.pause({ from: accounts[0] })
+    const starting0Balance = await token.balanceOf(accounts[1])
+    const starting1Balance = await token.balanceOf(accounts[2])
+    await token.transfer(accounts[2], txAmount, { from: accounts[1] })
+    await utils.assertEvent(token, { event: 'Transfer' })
+    const ending0Balance = await token.balanceOf(accounts[1])
+    const ending1Balance = await token.balanceOf(accounts[2])
     const expected0Bal = starting0Balance.minus(txAmount)
     const expected1Bal = starting1Balance.plus(txAmount)
     assert.equal(ending0Balance.toString(), expected0Bal.toString(), 'Balance of account 0 incorrect')
@@ -98,10 +116,9 @@ contract('MainframeToken', (accounts) => {
     assert(didFail, 'transfer succeeded when to address is token contract address')
   })
 
-  it('should allow transfer of tokens by anyone when tradeable set to true', async () => {
+  it('should allow transfer of tokens by anyone when not paused', async () => {
     const starting0Balance = await token.balanceOf(accounts[0])
     const starting2Balance = await token.balanceOf(accounts[2])
-    await token.turnOnTradeable({ from: accounts[0] })
     await token.transfer(accounts[1], txAmount, { from: accounts[0] })
     await utils.assertEvent(token, { event: 'Transfer' })
     await token.transfer(accounts[2], txAmount, { from: accounts[1] })
@@ -114,12 +131,13 @@ contract('MainframeToken', (accounts) => {
     assert.equal(ending2Balance.toString(), expected2Bal.toString(), 'Balance of account 1 incorrect')
   })
 
-  it('should not allow approve by non owner if tradeable is false ', async () => {
+  it('should not allow approve by non owner when paused ', async () => {
+    await token.pause({ from: accounts[0] })
     await token.transfer(accounts[1], txAmount, { from: accounts[0] })
     const failed = await utils.expectAsyncThrow(async () => {
       await token.approve(accounts[2], 500, { from: accounts[1] })
     })
-    assert(failed, 'approve succeeded by non owner when tradeable false')
+    assert(failed, 'approve succeeded by non owner when paused')
   })
 
   it('should not allow transferFrom when to address is invalid', async () => {
@@ -143,24 +161,40 @@ contract('MainframeToken', (accounts) => {
     assert(didFail)
   })
 
-  it('should allow transferFrom by owner when tradeable false', async () => {
+  it('should allow transferFrom by owner when paused', async () => {
+    await token.transfer(accounts[1], txAmount, { from: accounts[0] })
     const starting0Balance = await token.balanceOf(accounts[0])
     const starting1Balance = await token.balanceOf(accounts[1])
-    await token.turnOnTradeable({ from: accounts[0] })
-    await token.approve(accounts[1], txAmount, { from: accounts[0] })
+    await token.approve(accounts[0], txAmount, { from: accounts[1] })
     await utils.assertEvent(token, { event: 'Approval' })
-    await token.transferFrom(accounts[0], accounts[1], txAmount, { from: accounts[1] })
+    await token.pause({ from: accounts[0] })
+    await token.transferFrom(accounts[1], accounts[0], txAmount, { from: accounts[0] })
     const ending0Balance = await token.balanceOf(accounts[0])
     const ending1Balance = await token.balanceOf(accounts[1])
+    assert.equal(ending0Balance.toNumber(), starting0Balance.toNumber() + txAmount, 'Balance of account 0 incorrect')
+    assert.equal(ending1Balance.toNumber(), starting1Balance.toNumber() - txAmount, 'Balance of account 1 incorrect')
+  })
+
+  it('should allow transferFrom by distributor when paused', async () => {
+    const distributorAccount = accounts[1]
+    await token.setDistributor(distributorAccount, { from: accounts[0] })
+    await token.transfer(distributorAccount, txAmount, { from: accounts[0] })
+    const starting0Balance = await token.balanceOf(accounts[0])
+    const starting1Balance = await token.balanceOf(distributorAccount)
+    await token.approve(distributorAccount, txAmount, { from: accounts[0] })
+    await utils.assertEvent(token, { event: 'Approval' })
+    await token.pause({ from: accounts[0] })
+    await token.transferFrom(accounts[0], distributorAccount, txAmount, { from: distributorAccount })
+    const ending0Balance = await token.balanceOf(accounts[0])
+    const ending1Balance = await token.balanceOf(distributorAccount)
     assert.equal(ending0Balance.toNumber(), starting0Balance.toNumber() - txAmount, 'Balance of account 0 incorrect')
     assert.equal(ending1Balance.toNumber(), starting1Balance.toNumber() + txAmount, 'Balance of account 1 incorrect')
   })
 
-  it('should allow transferFrom by anyone when address has approved balance and tradeable turned on', async () => {
+  it('should allow transferFrom by anyone when address has approved balance and not paused', async () => {
     await token.transfer(accounts[1], txAmount, { from: accounts[0] })
     const starting0Balance = await token.balanceOf(accounts[1])
     const starting1Balance = await token.balanceOf(accounts[2])
-    await token.turnOnTradeable({ from: accounts[0] })
     await token.approve(accounts[2], txAmount, { from: accounts[1] })
     await utils.assertEvent(token, { event: 'Approval' })
     await token.transferFrom(accounts[1], accounts[2], txAmount, { from: accounts[2] })
@@ -172,9 +206,10 @@ contract('MainframeToken', (accounts) => {
 
   // ERC827 Tests
 
-  it('should not allow transfer (with data) by non owner if tradeable is false ', async () => {
+  it('should not allow transfer (with data) by non owner when paused ', async () => {
+    await token.pause({ from: accounts[0] })
     await token.transfer(accounts[1], txAmount, { from: accounts[0] })
-    const messageTest = await TestHelper.new();
+    const messageTest = await TestHelper.new()
     const extraData = messageTest.contract.showMessage.getData('transferred')
     const abiMethod = utils.findMethod(token.abi, 'transfer', 'address,uint256,bytes')
     const args = [messageTest.address, txAmount, extraData]
@@ -185,11 +220,12 @@ contract('MainframeToken', (accounts) => {
         data: transferData,
       })
     })
-    assert(failed, 'allowed transfer (with data) by non owner when not tradeable')
+    assert(failed, 'allowed transfer (with data) by non owner when paused')
   })
 
-  it('should allow transfer (with data) by owner when tradeable is false ', async () => {
-    const messageTest = await TestHelper.new();
+  it('should allow transfer (with data) by owner when paused ', async () => {
+    await token.pause({ from: accounts[0] })
+    const messageTest = await TestHelper.new()
     const extraData = messageTest.contract.showMessage.getData('transfer from account 0 to messageTest contract')
     const abiMethod = utils.findMethod(token.abi, 'transfer', 'address,uint256,bytes')
     const args = [messageTest.address, txAmount, extraData]
@@ -198,13 +234,29 @@ contract('MainframeToken', (accounts) => {
     await utils.assertEvent(token, { event: 'Transfer' })
     await utils.assertEvent(messageTest, { event: 'ShowMessage' })
     const account1Bal = await token.balanceOf(messageTest.address)
-    assert.equal(account1Bal.toNumber(), txAmount, 'transfer by owner failed when tradeable set to false')
+    assert.equal(account1Bal.toNumber(), txAmount, 'transfer by owner failed when paused')
   })
 
-  it('should allow transfer (with data) by anyone when tradeable is true ', async () => {
+  it('should allow transfer (with data) by distributor when paused ', async () => {
+    const distributorAccount = accounts[1]
     await token.transfer(accounts[1], txAmount, { from: accounts[0] })
-    await token.turnOnTradeable({ from: accounts[0] })
-    const messageTest = await TestHelper.new();
+    await token.setDistributor(distributorAccount, { from: accounts[0] })
+    await token.pause({ from: accounts[0] })
+    const messageTest = await TestHelper.new()
+    const extraData = messageTest.contract.showMessage.getData('transfer from distributor to messageTest contract')
+    const abiMethod = utils.findMethod(token.abi, 'transfer', 'address,uint256,bytes')
+    const args = [messageTest.address, txAmount, extraData]
+    const transferData = ethjsABI.encodeMethod(abiMethod, args)
+    const transaction = await token.sendTransaction({from: distributorAccount, data: transferData})
+    await utils.assertEvent(token, { event: 'Transfer' })
+    await utils.assertEvent(messageTest, { event: 'ShowMessage' })
+    const account1Bal = await token.balanceOf(messageTest.address)
+    assert.equal(account1Bal.toNumber(), txAmount, 'transfer by distributor failed when paused')
+  })
+
+  it('should allow transfer (with data) by anyone when not paused ', async () => {
+    await token.transfer(accounts[1], txAmount, { from: accounts[0] })
+    const messageTest = await TestHelper.new()
     const extraData = messageTest.contract.showMessage.getData('transfer from account 1 to messageTest contract')
     const abiMethod = utils.findMethod(token.abi, 'transfer', 'address,uint256,bytes')
     const args = [messageTest.address, txAmount, extraData]
@@ -213,12 +265,13 @@ contract('MainframeToken', (accounts) => {
     await utils.assertEvent(token, { event: 'Transfer' })
     await utils.assertEvent(messageTest, { event: 'ShowMessage' })
     const account1Bal = await token.balanceOf(messageTest.address)
-    assert.equal(account1Bal.toNumber(), txAmount, 'transfer failed when tradeable set to true')
+    assert.equal(account1Bal.toNumber(), txAmount, 'transfer failed when not paused')
   })
 
-  it('should not allow approve (with data) by non owner when tradeable is false ', async () => {
+  it('should not allow approve (with data) by non owner when paused ', async () => {
+    await token.pause({ from: accounts[0] })
     await token.transfer(accounts[1], txAmount, { from: accounts[0] })
-    const messageTest = await TestHelper.new();
+    const messageTest = await TestHelper.new()
     const extraData = messageTest.contract.showMessage.getData('approved')
     const abiMethod = utils.findMethod(token.abi, 'approve', 'address,uint256,bytes')
     const args = [accounts[2], txAmount, extraData]
@@ -229,11 +282,12 @@ contract('MainframeToken', (accounts) => {
         data: transferData,
       })
     })
-    assert(failed, 'approve (with data) succeeded for non owner when tradeable set to false')
+    assert(failed, 'approve (with data) succeeded for non owner when paused')
   })
 
-  it('should approve (with data) correct allowance by owner when tradeable is false ', async () => {
-    const messageTest = await TestHelper.new();
+  it('should approve (with data) correct allowance by owner when paused ', async () => {
+    await token.pause({ from: accounts[0] })
+    const messageTest = await TestHelper.new()
     const extraData = messageTest.contract.showMessage.getData(`account 0 approved ${txAmount} for messageTest contract`)
     const abiMethod = utils.findMethod(token.abi, 'approve', 'address,uint256,bytes')
     const args = [messageTest.address, txAmount, extraData]
@@ -242,13 +296,29 @@ contract('MainframeToken', (accounts) => {
     await utils.assertEvent(token, { event: 'Approval' })
     await utils.assertEvent(messageTest, { event: 'ShowMessage' })
     const allowance = await token.allowance(accounts[0], messageTest.address)
-    assert.equal(allowance.toNumber(), txAmount, 'incorrect allowance approved by owner when tradeable false')
+    assert.equal(allowance.toNumber(), txAmount, 'incorrect allowance approved by owner when paused')
   })
 
-  it('should approve (with data) correct allowance by anyone when tradeable is true ', async () => {
-    await token.turnOnTradeable({ from: accounts[0] })
+  it('should approve (with data) correct allowance by distributor when paused ', async () => {
+    const distributorAccount = accounts[1]
     await token.transfer(accounts[1], txAmount, { from: accounts[0] })
-    const messageTest = await TestHelper.new();
+    await token.setDistributor(distributorAccount, { from: accounts[0] })
+    await token.pause({ from: accounts[0] })
+    const messageTest = await TestHelper.new()
+    const extraData = messageTest.contract.showMessage.getData(`distributor approved ${txAmount} for messageTest contract`)
+    const abiMethod = utils.findMethod(token.abi, 'approve', 'address,uint256,bytes')
+    const args = [messageTest.address, txAmount, extraData]
+    const transferData = ethjsABI.encodeMethod(abiMethod, args)
+    await token.sendTransaction({from: distributorAccount, data: transferData})
+    await utils.assertEvent(token, { event: 'Approval' })
+    await utils.assertEvent(messageTest, { event: 'ShowMessage' })
+    const allowance = await token.allowance(distributorAccount, messageTest.address)
+    assert.equal(allowance.toNumber(), txAmount, 'incorrect allowance approved by owner when paused')
+  })
+
+  it('should approve (with data) correct allowance by anyone when not paused ', async () => {
+    await token.transfer(accounts[1], txAmount, { from: accounts[0] })
+    const messageTest = await TestHelper.new()
     const extraData = messageTest.contract.showMessage.getData(`account 1 approved ${txAmount} for messageTest contract`)
     const abiMethod = utils.findMethod(token.abi, 'approve', 'address,uint256,bytes')
     const args = [messageTest.address, txAmount, extraData]
@@ -257,12 +327,11 @@ contract('MainframeToken', (accounts) => {
     await utils.assertEvent(token, { event: 'Approval' })
     await utils.assertEvent(messageTest, { event: 'ShowMessage' })
     const allowance = await token.allowance(accounts[1], messageTest.address)
-    assert.equal(allowance.toNumber(), txAmount, 'incorrect allowance approved by owner when tradeable false')
+    assert.equal(allowance.toNumber(), txAmount, 'incorrect allowance approved by owner when paused')
   })
 
   it('should approve (with data) and call transferFrom in single transaction', async () => {
-    await token.turnOnTradeable({ from: accounts[0] })
-    const depositTest = await TestHelper.new();
+    const depositTest = await TestHelper.new()
     const extraData = depositTest.contract.deposit.getData(accounts[0], token.address, txAmount)
     const abiMethod = utils.findMethod(token.abi, 'approve', 'address,uint256,bytes')
     const args = [depositTest.address, txAmount, extraData]
@@ -274,9 +343,10 @@ contract('MainframeToken', (accounts) => {
     assert.equal(balance.toNumber(), txAmount, 'incorrect balance after approve and stake')
   })
 
-  it('should not allow transferFrom (with data) by non owner when tradeable is false ', async () => {
+  it('should not allow transferFrom (with data) by non owner when paused ', async () => {
     await token.approve(accounts[1], txAmount, { from: accounts[0] })
-    const messageTest = await TestHelper.new();
+    await token.pause({ from: accounts[0] })
+    const messageTest = await TestHelper.new()
     const extraData = messageTest.contract.showMessage.getData('transferFrom failed')
     const abiMethod = utils.findMethod(token.abi, 'transferFrom', 'address,address,uint256,bytes')
     const args = [accounts[0], accounts[1], txAmount, extraData]
@@ -287,32 +357,47 @@ contract('MainframeToken', (accounts) => {
         data: transferData,
       })
     })
-    assert(failed, 'transferFrom (with data) succeeded for non owner when tradeable set to false')
+    assert(failed, 'transferFrom (with data) succeeded for non owner when paused')
   })
 
-  it('should allow transferFrom (with data) by owner when tradeable is false ', async () => {
+  it('should allow transferFrom (with data) by owner when paused ', async () => {
+    await token.pause({ from: accounts[0] })
     await token.approve(accounts[0], txAmount, { from: accounts[0] })
-    const messageTest = await TestHelper.new();
+    const messageTest = await TestHelper.new()
     const extraData = messageTest.contract.showMessage.getData(`transferred ${txAmount} from account 0 to account 1`)
     const abiMethod = utils.findMethod(token.abi, 'transferFrom', 'address,address,uint256,bytes')
     const args = [accounts[0], accounts[1], txAmount, extraData]
     const transferData = ethjsABI.encodeMethod(abiMethod, args)
     await token.sendTransaction({from: accounts[0], data: transferData})
     const account1Bal = await token.balanceOf(accounts[1])
-    assert.equal(account1Bal.toNumber(), txAmount, 'transferFrom failed for owner when tradeable set to false')
+    assert.equal(account1Bal.toNumber(), txAmount, 'transferFrom failed for owner when paused')
   })
 
-  it('should allow transferFrom (with data) by anyone when tradeable is true ', async () => {
-    await token.turnOnTradeable({ from: accounts[0] })
+  it('should allow transferFrom (with data) by distributor when paused ', async () => {
+    const distributorAccount = accounts[1]
+    await token.setDistributor(distributorAccount, { from: accounts[0] })
+    await token.pause({ from: accounts[0] })
+    await token.approve(distributorAccount, txAmount, { from: accounts[0] })
+    const messageTest = await TestHelper.new()
+    const extraData = messageTest.contract.showMessage.getData(`transferred ${txAmount} from account 0 to account 1 by distributor`)
+    const abiMethod = utils.findMethod(token.abi, 'transferFrom', 'address,address,uint256,bytes')
+    const args = [accounts[0], distributorAccount, txAmount, extraData]
+    const transferData = ethjsABI.encodeMethod(abiMethod, args)
+    await token.sendTransaction({from: distributorAccount, data: transferData})
+    const account1Bal = await token.balanceOf(distributorAccount)
+    assert.equal(account1Bal.toNumber(), txAmount, 'inorrect distributor balance')
+  })
+
+  it('should allow transferFrom (with data) by anyone when not paused ', async () => {
     await token.transfer(accounts[1], txAmount, { from: accounts[0] })
     await token.approve(accounts[2], txAmount, { from: accounts[1] })
-    const messageTest = await TestHelper.new();
+    const messageTest = await TestHelper.new()
     const extraData = messageTest.contract.showMessage.getData(`transferred ${txAmount} from account 1 to account 2`)
     const abiMethod = utils.findMethod(token.abi, 'transferFrom', 'address,address,uint256,bytes')
     const args = [accounts[1], accounts[2], txAmount, extraData]
     const transferData = ethjsABI.encodeMethod(abiMethod, args)
     await token.sendTransaction({from: accounts[2], data: transferData})
     const account1Bal = await token.balanceOf(accounts[2])
-    assert.equal(account1Bal.toNumber(), txAmount, 'transferFrom failed for owner when tradeable set to false')
+    assert.equal(account1Bal.toNumber(), txAmount, 'transferFrom failed when not paused')
   })
 })


### PR DESCRIPTION
These changes allow our distribution contract as well as token contract owner to perform transfers whilst the token is not tradeable.

- Added distributor variable to token
- Made token inherit from pausable
- Updated the tradeable modifier to return true if not paused or sender is owner or distributor 

I've also made the token claimable, an extension to ownable, which would allow us to set a pending owner who could claim ownership if we lost access to owner account.