### PR TITLE
sender checks in stake function

### DIFF
--- a/contracts/MainframeStake.sol
+++ b/contracts/MainframeStake.sol
@@ -34,6 +34,7 @@ contract MainframeStake is Ownable, StakeInterface {
 
   function stake(address staker, address whitelistAddress) external returns (bool success) {
     require(whitelist[whitelistAddress].stakerAddress == 0x0);
+    require(staker == msg.sender || (msg.sender == address(token) && staker == tx.origin));
 
     whitelist[whitelistAddress].stakerAddress = staker;
     whitelist[whitelistAddress].stakedAmount = requiredStake;


### PR DESCRIPTION
This allows us to validate the staker address, either a user staking by directly interacting with the contract or if a user stakes in a single transaction via the approveAndCall method from the token contract. 